### PR TITLE
Enable listener for additional events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,11 +89,10 @@ export default class SimpleMDEEditor extends Component {
 
     this.simplemde.codemirror.on("cursorActivity", this.getCursor);
     
- 
     const { events } = this.props;
     
     // Handle custom events
-    Object.entries(events).forEach(([eventName, callback]) => {
+    events && Object.entries(events).forEach(([eventName, callback]) => {
       if(eventName && callback) {
         this.simplemde.codemirror.on(eventName, callback);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export default class SimpleMDEEditor extends Component {
   };
 
   static defaultProps = {
+    events: {},
     onChange: NOOP,
     options: {}
   };
@@ -92,7 +93,7 @@ export default class SimpleMDEEditor extends Component {
     const { events } = this.props;
     
     // Handle custom events
-    events && Object.entries(events).forEach(([eventName, callback]) => {
+    Object.entries(events).forEach(([eventName, callback]) => {
       if(eventName && callback) {
         this.simplemde.codemirror.on(eventName, callback);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,16 @@ export default class SimpleMDEEditor extends Component {
       this.editorToolbarEl.addEventListener("click", this.eventWrapper);
 
     this.simplemde.codemirror.on("cursorActivity", this.getCursor);
+    
+ 
+    const { events } = this.props;
+    
+    // Handle custom events
+    Object.entries(events).forEach(([eventName, callback]) => {
+      if(eventName && callback) {
+        this.simplemde.codemirror.on(eventName, callback);
+      }
+    });
   };
 
   getCursor = () => {


### PR DESCRIPTION
Fix for https://github.com/RIP21/react-simplemde-editor/issues/67

### Usage
``` JSX
<SimpleMDE
  onChange={this.handleChange}
  events={
    'blur': (e) => {},
    'focus': (e) => {},
    //... Add any codeMirror events
  }
/>
```
See full list of events: https://codemirror.net/doc/manual.html#events