### PR TITLE
Export props-type for external consumption

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,7 @@ type SimpleMdeToCodemirror = {
   [E in CodemirrorEvents | DOMEvent]: Editor["on"]
 };
 
-type SimpleMDEEditorProps = {
+export interface SimpleMDEEditorProps {
   id?: string;
   label?: string;
   onChange: (value: string) => void | any;


### PR DESCRIPTION
This patch exports `SimpleMDEEditorProps` so that it can be used outside of the module. It also changes it to an interface instead of a type so that it can be `extends`-ed or `implements`-ed by others.

My use case is to have a small wrapper module which customizes the toolbar for my project. I then want to be able to accept all the original properties, and my own. Something like this:

```typescript
import SimpleMDE, { SimpleMDEEditorProps } from 'react-simplemde-editor'

interface MarkdownEditorProps extends SimpleMDEEditorProps {
  foobar: string
}

const MarkdownEditor: React.FunctionComponent<MarkdownEditorProps> = ({ foobar, ...props }) => {
  // do something with foobar

  return <SimpleMDE {...props} />
}
```