### PR TITLE
Fix typescript for events

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,8 +21,8 @@ type CodemirrorEvents =
   | "update"
   | "renderLine";
 
-type SimpleMdeToCodemirror = {
-  [E in CodemirrorEvents | DOMEvent]: Editor["on"]
+type SimpleMdeToCodemirror = { 
+  [E in CodemirrorEvents | DOMEvent]?: Editor["on"]
 };
 
 export interface SimpleMDEEditorProps {


### PR DESCRIPTION

>  It looks like the interface requires all 23 of the event types on the object, where it should rather make them optional. Just on my phone right now, will give the full error when I’m back home. Happy to help with a PR if you need.

See: https://github.com/RIP21/react-simplemde-editor/pull/68#issuecomment-504116562