### PR TITLE
Update EasyMDE version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@types/codemirror": "^0.0.65",
-    "easymde": "^2.6.0"
+    "easymde": "^2.7.1-202.0"
   },
   "peerDependencies": {
     "react": ">=15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,10 +2389,10 @@ codemirror-spell-checker@1.1.2:
   dependencies:
     typo-js "*"
 
-codemirror@^5.43.0:
-  version "5.45.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.45.0.tgz#db5ebbb3bf44028c684053f3954d011efcec27ad"
-  integrity sha512-c19j644usCE8gQaXa0jqn2B/HN9MnB2u6qPIrrhrMkB+QAP42y8G4QnTwuwbVSoUS1jEl7JU9HZMGhCDL0nsAw==
+codemirror@^5.48.0:
+  version "5.48.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.48.2.tgz#a9dd3d426dea4cd59efd59cd98e20a9152a30922"
+  integrity sha512-i9VsmC8AfA5ji6EDIZ+aoSe4vt9FcwPLdHB1k1ItFbVyuOFRrcfvnoKqwZlC7EVA2UmTRiNEypE4Uo7YvzVY8Q==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -3276,14 +3276,14 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-easymde@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.6.0.tgz#9ee35ee10f285bf41dca2e0e9e4f2fe8e818735c"
-  integrity sha512-WhSvcAqBFfSGeSkanib2+WN7K9Ri+AS1vGXUyDs/tTaaKjVNwiuWjlKiRkV4AJjC45QPjT1GfZmIrQEgs9dlTA==
+easymde@^2.7.1-202.0:
+  version "2.7.1-202.0"
+  resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.7.1-202.0.tgz#98487a95299390737b5360fc07818c833f80d72f"
+  integrity sha512-oZ+bqsbW6OkTagdevf1//nqBIS1KwAeSGBH6eYxl2WCARmMl0gSJK16wK3grWJseFv9fHom5SSvyd1lDcZ3Ydw==
   dependencies:
-    codemirror "^5.43.0"
+    codemirror "^5.48.0"
     codemirror-spell-checker "1.1.2"
-    marked "^0.6.2"
+    marked "^0.7.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -6102,10 +6102,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.2.tgz#c574be8b545a8b48641456ca1dbe0e37b6dccc1a"
-  integrity sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
Hey @RIP21, a new version of `EasyMDE` has just been released today. That version allows users to upload images when someone selects, pastes or drops an image in the editor (version `2.7.1-202.0` https://www.npmjs.com/package/easymde/v/next). It would be possible to have a version of `React SimpleMDE` with that version of EasyMDE as npm@next? 

Thank you in advance.