### PR TITLE
add simpleMde change Event

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -139,6 +139,7 @@ export default class SimpleMDEEditor extends React.PureComponent<
       this.editorToolbarEl &&
         this.editorToolbarEl.addEventListener("click", this.eventWrapper);
 
+      this.simpleMde.codemirror.on("change", this.eventWrapper);
       this.simpleMde.codemirror.on("cursorActivity", this.getCursor);
 
       const { events } = this.props;


### PR DESCRIPTION
issue link : https://github.com/RIP21/react-simplemde-editor/issues/125

I found a bug that does not call **onChange** after **options.imageUploadFunction** finished. So I added the ` this.simpleMde.codemirror.on("change", this.eventWrapper); ` event so that it will occur when the value itself changes, not just for the key event.

[src/index.tsx](https://github.com/JaeSeoKim/react-simplemde-editor/commit/9a54c4e3e1c4aa49e58dbea197eed2f557d19311#diff-38682f47b0cf12c516bc3714fc45d0fd) 

```typescript
...
       this.editorToolbarEl &&
         this.editorToolbarEl.addEventListener("click", this.eventWrapper);

 +     this.simpleMde.codemirror.on("change", this.eventWrapper);
       this.simpleMde.codemirror.on("cursorActivity", this.getCursor);

       const { events } = this.props;
...
```

