### PR TITLE
Reinstall custom event handlers when component updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,16 @@ See full list of events: https://codemirror.net/doc/manual.html#events
   value={this.state.text}
   onChange={this.handleChange}
   events={{
-    'blur': (e) => {},
-    'focus': (e) => {},
+    'blur': {this.onBlur},
+    'focus': {this.onFocus},
     //... Add any codeMirror events
   }}
 />
 ```
+
+If changed, the event handlers are reinstalled on component update. Make sure to use instance
+methods or `useCallback`. Anonymous functions à la `'focus': (e) => { ... }` are considered
+inequal by definition and will cause unecessary event handler updates.
 
 ### Autosaving example
 

--- a/README.md
+++ b/README.md
@@ -147,16 +147,12 @@ See full list of events: https://codemirror.net/doc/manual.html#events
   value={this.state.text}
   onChange={this.handleChange}
   events={{
-    'blur': {this.onBlur},
-    'focus': {this.onFocus},
+    'blur': (e) => {},
+    'focus': (e) => {},
     //... Add any codeMirror events
   }}
 />
 ```
-
-If changed, the event handlers are reinstalled on component update. Make sure to use instance
-methods or `useCallback`. Anonymous functions à la `'focus': (e) => { ... }` are considered
-inequal by definition and will cause unecessary event handler updates.
 
 ### Autosaving example
 

--- a/demo/src/Demo.js
+++ b/demo/src/Demo.js
@@ -42,6 +42,12 @@ class Demo extends React.Component {
   };
 
   render() {
+    let events = {
+      'focus': () => console.log('focus')
+    };
+    if (counter % 2 === 0) {
+      events['blur'] = () => console.log('blur')
+    }
     return (
       <div className="container container-narrow">
         <div className="page-header">
@@ -68,6 +74,7 @@ class Demo extends React.Component {
           label="Markdown Editor"
           value={this.state.textValue1}
           onChange={this.handleChange1}
+          events={events}
         />
         <hr />
         <SimpleMDEReact

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -92,6 +92,8 @@ export default class SimpleMDEEditor extends React.PureComponent<
       this.simpleMde!.value(this.props.value || "");
     }
     this.keyChange = false;
+
+    this.updateCustomEvents(this.props.events, prevProps.events);
   }
 
   componentWillUnmount() {
@@ -156,20 +158,31 @@ export default class SimpleMDEEditor extends React.PureComponent<
       this.simpleMde.codemirror.on("change", this.eventWrapper);
       this.simpleMde.codemirror.on("cursorActivity", this.getCursor);
 
-      const { events } = this.props;
-
-      // Handle custom events
-      events &&
-        Object.entries(events).forEach(([eventName, callback]) => {
-          if (eventName && callback) {
-            this.simpleMde &&
-              this.simpleMde.codemirror.on(
-                eventName as DOMEvent,
-                callback as any
-              );
-          }
-        });
+      this.updateCustomEvents(this.props.events)
     }
+  };
+
+  updateCustomEvents = (events: SimpleMdeToCodemirror | undefined, prevEvents?: SimpleMdeToCodemirror | undefined) => {
+    prevEvents &&
+      Object.entries(prevEvents).forEach(([eventName, callback]) => {
+        if (eventName && callback && (events?.[eventName as CodemirrorEvents | DOMEvent]) !== callback) {
+          this.simpleMde &&
+            this.simpleMde.codemirror.off(
+              eventName as DOMEvent,
+              callback as any
+            );
+        }
+      });
+    events &&
+      Object.entries(events).forEach(([eventName, callback]) => {
+        if (eventName && callback && prevEvents?.[eventName as CodemirrorEvents | DOMEvent] !== callback) {
+          this.simpleMde &&
+            this.simpleMde.codemirror.on(
+              eventName as DOMEvent,
+              callback as any
+            );
+        }
+      });
   };
 
   getCursor = () => {


### PR DESCRIPTION
This adds support for changing custom event handlers after the component has mounted. On every update of the component, the event handlers in the previous and current props are compared and (un)installed accordingly.

Not much of a react expert so looking forward to candid feedback. 🙂 

Fixes: #156