### PR TITLE
Drop unused @types/marked dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "src"
   ],
   "dependencies": {
-    "@types/codemirror": "0.0.109",
-    "@types/marked": "^2.0.2"
+    "@types/codemirror": "0.0.109"
   },
   "peerDependencies": {
     "easymde": ">= 2.0.0 < 3.0.0",


### PR DESCRIPTION
The yarn.lock didn't have any changes b/c the same package is the one used by the easymde version in the lock, so they get deduplicated.
But that's not true for easymde@v2.16.1 (the latest atm) which uses @types/marked@v4.0.1, and b/c of the way that @types/marked@v4.0.0 moved away from `export as namespace marked;` type of type exports, this atm causes a type clash:
```
$ npx tsc
node_modules/easymde/types/easymde.d.ts:24:10 - error TS2616: 'marked' can only be imported by using 'import marked = require("../../@types/marked")' or a default import.

24 import { marked } from 'marked';
            ~~~~~~


Found 1 error.
```
Removing the additional v2 of @types/marked from our node_modules (like this PR does) seems to be fixing it.