### PR TITLE
Pass changeObject to onChange

### DIFF
--- a/src/SimpleMdeReact.tsx
+++ b/src/SimpleMdeReact.tsx
@@ -191,10 +191,10 @@ export const SimpleMdeReact = React.forwardRef<
     nonEventChangeRef.current = true;
   }, [editor, value]);
 
-  const onCodemirrorChangeHandler = useCallback(() => {
+  const onCodemirrorChangeHandler = useCallback((_, changeObject) => {
     if (editor?.value() !== currentValueRef.current) {
       nonEventChangeRef.current = false;
-      onChange?.(editor?.value() ?? "");
+      onChange?.(editor?.value() ?? "", changeObject);
     }
   }, [editor, onChange]);
 


### PR DESCRIPTION
There are cases where it's useful to know which type of change was made (specific key press, paste from clipboard) and while it is possible to achieve this by adding another `change` handler to the CodeMirror instance, this seems to be _simple_

From CodeMirror's docs:
> "change" (instance: CodeMirror, changeObj: object)
Fires every time the content of the editor is changed. The changeObj is a {from, to, text, removed, origin} object containing information about the changes that occurred as second argument. from and to are the positions (in the pre-change coordinate system) where the change started and ended (for example, it might be {ch:0, line:18} if the position is at the beginning of line #19). text is an array of strings representing the text that replaced the changed range (split by line). removed is the text that used to be between from and to, which is overwritten by this change. This event is fired before the end of an [operation](https://codemirror.net/doc/manual.html#operation), before the DOM updates happen.